### PR TITLE
Merge Trees

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,10 +12,10 @@
             <th>Status</th>
             <th>Actions</th>
         </tr>
-        {% for node in data %}
+        {% for i in range(length) %}
             <tr>
-                <td>{{ node.name }}</td>
-                <td>{{ node.status}}</td>
+                <td>{{ names[i] }}</td>
+                <td>{{ status[i] }}</td>
             </tr>
         {% endfor %}
     </table>

--- a/resource_manager.py
+++ b/resource_manager.py
@@ -4,7 +4,7 @@ import json
 from io import BytesIO
 
 cURL = pycurl.Curl()
-proxy_url = 'http://192.168.2.14:6000/'
+proxy_url = 'http://10.122.56.210:6000/'
 
 app = Flask(__name__)
 
@@ -16,7 +16,9 @@ def render_page():
     cURL.setopt(cURL.WRITEFUNCTION, data.write)
     cURL.perform()
     data = json.loads(data.getvalue())
-    return render_template("index.html", data=data)
+    print(data)
+    length = len(data[0])
+    return render_template("index.html", names = data[0], status = data[1], length = length)
 
 
 @app.route('/', methods=['GET', 'POST'])
@@ -64,11 +66,10 @@ def cloud_init():
         cURL.perform()
         dictionary = json.loads(data.getvalue())
         print(dictionary)
+        render_page()
 
         result = dictionary['result']
         new_node_pod = 'default'
-        
-        render_page()
         return jsonify({'result': result})
 
 
@@ -84,7 +85,6 @@ def cloud_pod_register(pod_name):
         print(dictionary)
 
         result = dictionary['result']
-        render_page()
         return jsonify({'result': result})
 
 
@@ -101,7 +101,6 @@ def cloud_pod_rm(pod_name):
 
         print(dictionary)
         result = dictionary['result']
-        render_page()
         return jsonify({'result': result})
 
 


### PR DESCRIPTION
modifications:
proxy:
1. get_data() function modified the input of josnify as jason cannot take container value
2. cloud register(): node structures changed to cantianers, with attribute name, status(created instead of idle), and many others, please look at the reference https://docker-py.readthedocs.io/en/stable/containers.html
3. check if there is a job inside of jobs[], if so, create mutex lock and create a new container with job as input NOTE: here I just put job[0] as input, please make modifications if needed based on the launch function 4.cloud init(): node structures changed into container, newly created node's status no longer 'idel' ('created')
5. pod_register/rm unchanged

resource_manage.py
1.render_page() chanced the input of render templates

index.html
small modification was made based on the input change of render_templates(works well)

Please note that the structure of node changed from dictionary to Container. Thus, instead of calling key and value, please make sure you are using the attributes of the Container Item.

I am sorry for these many modifications need to be made just because of the node structure.  Cheers!